### PR TITLE
MW-1207: Adjust reports table view to support categories

### DIFF
--- a/src/report/messages_en.json
+++ b/src/report/messages_en.json
@@ -1,7 +1,7 @@
 {
   "report.xlsx": "XLSX",
   "report.superset.reports": "Reports",
-  "report.LMISReports": "LMIS Reports",
+  "report.lmisReports": "LMIS Reports",
   "report.additionalReports": "Additional Reports",
   "report.dashboardReports": "Dashboard Reports"
 }

--- a/src/report/messages_en.json
+++ b/src/report/messages_en.json
@@ -1,4 +1,7 @@
 {
   "report.xlsx": "XLSX",
-  "report.superset.reports": "Reports"
+  "report.superset.reports": "Reports",
+  "report.LMISReports": "LMIS Reports",
+  "report.additionalReports": "Additional Reports",
+  "report.dashboardReports": "Dashboard Reports"
 }

--- a/src/report/report-list.controller.js
+++ b/src/report/report-list.controller.js
@@ -36,7 +36,7 @@
         vm.hasRight = hasRight;
 
         // MW-1207: Adjust reports table view to support categories
-        const LMISReports = reports.filter((report) => {
+        const lmisReports = reports.filter((report) => {
             return report.category === 'LMIS Reports';
         });
 
@@ -47,13 +47,13 @@
         /**
          * @ngdoc property
          * @propertyOf report.controller:ReportListController
-         * @name LMISReports
+         * @name lmisReports
          * @type {Array}
          *
          * @description
          * The list of all available LMIS reports.
          */
-        vm.LMISReports = LMISReports;
+        vm.lmisReports = lmisReports;
         
         /**
          * @ngdoc property

--- a/src/report/report-list.controller.js
+++ b/src/report/report-list.controller.js
@@ -1,0 +1,118 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc controller
+     * @name report.controller:ReportListController
+     *
+     * @description
+     * Controller for report list view page.
+     */
+    angular
+        .module('report')
+        .controller('ReportListController', controller);
+
+    controller.$inject = ['$state', 'reports', 'supersetReports', 'permissions', 'REPORT_RIGHTS'];
+
+    function controller($state, reports, supersetReports, permissions,
+                        REPORT_RIGHTS) {
+        var vm = this;
+        vm.hasRight = hasRight;
+
+        // MW-1207: Adjust reports table view to support categories
+        const LMISReports = reports.filter((report) => {
+            return report.category === 'LMIS Reports';
+        });
+
+        const additionalReports = reports.filter((report) => {
+            return report.category === 'Additional Reports';
+        });
+
+        /**
+         * @ngdoc property
+         * @propertyOf report.controller:ReportListController
+         * @name LMISReports
+         * @type {Array}
+         *
+         * @description
+         * The list of all available LMIS reports.
+         */
+        vm.LMISReports = LMISReports;
+        
+        /**
+         * @ngdoc property
+         * @propertyOf report.controller:ReportListController
+         * @name additionalReports
+         * @type {Array}
+         *
+         * @description
+         * The list of all available additional reports.
+         */
+        vm.additionalReports = additionalReports;
+        // MW-1207: Ends here
+
+        /**
+         * @ngdoc property
+         * @propertyOf report.controller:ReportListController
+         * @name reports
+         * @type {Array}
+         *
+         * @description
+         * The list of all available reports.
+         */
+        vm.reports = reports;
+
+        /**
+         * @ngdoc property
+         * @propertyOf report.controller:ReportListController
+         * @name supersetReports
+         * @type {Object}
+         *
+         * @description
+         * Contains information about available superset reports.
+         */
+        vm.supersetReports = supersetReports.getReports();
+
+        /**
+         * @ngdoc property
+         * @propertyOf report.controller:ReportListController
+         * @name permissions
+         * @type {Object}
+         *
+         * @description
+         * Contains information about user report rights.
+         */
+        vm.permissions = permissions;
+
+        /**
+         * @ngdoc method
+         * @methodOf report.controller:ReportListController
+         * @name hasRight
+         *
+         * @description
+         * Returns true if user has right to manage the proper report.
+         *
+         * @param {String}   rightName  the right name
+         * @return {Boolean}            true if the user has the right, otherwise false
+         */
+        function hasRight(rightName) {
+            return vm.permissions[rightName] || vm.permissions[REPORT_RIGHTS.REPORTS_VIEW];
+        }
+    }
+})();

--- a/src/report/report-list.html
+++ b/src/report/report-list.html
@@ -1,0 +1,62 @@
+<h2>{{'report.viewReports' | message}}</h2>
+<!-- MW-1207: Adjust reports table view to support categories -->
+<div style="display:flex">
+    <div class="openlmis-table-container">
+        <table>
+            <caption class="error" ng-show="!vm.reports.length && !vm.supersetReports">
+                {{'report.noReports' | message}}
+            </caption>
+            <thead>
+                <tr>
+                    <th>{{'report.LMISReports' | message}}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="report in vm.LMISReports">
+                    <td>
+                        <a ui-sref=".generate({module: report.$module, report: report.id})">{{report.name}}</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="openlmis-table-container">
+        <table>
+            <caption class="error" ng-show="!vm.reports.length && !vm.supersetReports">
+                {{'report.noReports' | message}}
+            </caption>
+            <thead>
+                <tr>
+                    <th>{{'report.additionalReports' | message}}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="report in vm.additionalReports">
+                    <td>
+                        <a ui-sref=".generate({module: report.$module, report: report.id})">{{report.name}}</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="openlmis-table-container">
+        <table>
+            <caption class="error" ng-show="!vm.reports.length && !vm.supersetReports">
+                {{'report.noReports' | message}}
+            </caption>
+            <thead>
+                <tr>
+                    <th>{{'report.dashboardReports' | message}}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="report in vm.supersetReports">
+                    <td ng-if="vm.hasRight(report.right)">
+                        <a ui-sref="{{'.superset.' + report.code}}">{{ 'report.superset.' + report.code | message}}</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<!-- MW-1207: Ends here -->

--- a/src/report/report-list.html
+++ b/src/report/report-list.html
@@ -8,11 +8,11 @@
             </caption>
             <thead>
                 <tr>
-                    <th>{{'report.LMISReports' | message}}</th>
+                    <th>{{'report.lmisReports' | message}}</th>
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="report in vm.LMISReports">
+                <tr ng-repeat="report in vm.lmisReports">
                     <td>
                         <a ui-sref=".generate({module: report.$module, report: report.id})">{{report.name}}</a>
                     </td>


### PR DESCRIPTION
Reports are now displayed in their category table
(Dashboard reports table is empty because superset reports names are not displayed locally)
![image](https://user-images.githubusercontent.com/110475297/202431064-16526312-0289-408f-8d0b-0c6fe4ab04ee.png)
